### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/aireview.yaml
+++ b/.github/workflows/aireview.yaml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   annotate-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/AleksandrFurmenkovOfficial/ai-code-review/security/code-scanning/2](https://github.com/AleksandrFurmenkovOfficial/ai-code-review/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it appears that it primarily interacts with pull requests and repository contents. Therefore, we will set `contents: read` and `pull-requests: write` as the permissions. These permissions allow the workflow to read repository contents and write comments or annotations to pull requests, which aligns with its purpose.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
